### PR TITLE
feat(Bookings): view bookings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## WAYFARER APP
 
-[![Build Status](https://travis-ci.org/WinnersProx/way-farer-app.svg?branch=develop)](https://travis-ci.org/WinnersProx/way-farer-app) [![Coverage Status](https://coveralls.io/repos/github/WinnersProx/way-farer-app/badge.svg)](https://coveralls.io/github/WinnersProx/way-farer-app?branch=ft-delete-booking-api-167417718) [![Maintainability](https://api.codeclimate.com/v1/badges/ac59e2bbb7a54a77685e/maintainability)](https://codeclimate.com/github/WinnersProx/way-farer-app/maintainability)
+[![Build Status](https://travis-ci.org/WinnersProx/way-farer-app.svg?branch=develop)](https://travis-ci.org/WinnersProx/way-farer-app) [![Coverage Status](https://coveralls.io/repos/github/WinnersProx/way-farer-app/badge.svg)](https://coveralls.io/github/WinnersProx/way-farer-app?branch=ft-view-bookings-api-167417712) [![Maintainability](https://api.codeclimate.com/v1/badges/ac59e2bbb7a54a77685e/maintainability)](https://codeclimate.com/github/WinnersProx/way-farer-app/maintainability)
 
 ## Platform Description
 

--- a/server/controllers/bookings_controller.js
+++ b/server/controllers/bookings_controller.js
@@ -23,6 +23,13 @@ const bookingsController = {
             status : "success",
             data   : { message : "Booking deleted successfully"}
         })
+    },
+    viewBookings : (req, res) => {
+        const bookings = (req.user.is_admin) ? Bookings.findAll('bookings') : Bookings.findUserBookings(req.user.id);
+        return res.status(200).send({
+            status : "success",
+            data   :  bookings 
+        })
     }
 }
 export default bookingsController

--- a/server/models/bookings.js
+++ b/server/models/bookings.js
@@ -7,5 +7,8 @@ class BookingsModel extends Model{
   	delete(bookingId){
   		db.bookings.splice((bookingId - 1),1);
   	}
+  	findUserBookings(userId){
+  		return db.bookings.filter(booking => booking.user_id === userId);
+  	}
 }
 export default new BookingsModel();

--- a/server/routes/bookings.js
+++ b/server/routes/bookings.js
@@ -7,4 +7,5 @@ const routes = express.Router()
 routes
 .post('/bookings', authValidations.checkUserToken, bookingsValidations.validateBooking, bookingsValidations.isSeatAvailable,bookingsController.bookSeat)
 .delete('/bookings/:booking_id', authValidations.checkUserToken, bookingsValidations.validateDelete, bookingsController.deleteBooking)
+.get('/bookings/', authValidations.checkUserToken, bookingsController.viewBookings)
 export default routes;

--- a/server/tests/bookings.test.js
+++ b/server/tests/bookings.test.js
@@ -225,12 +225,11 @@ describe('Bookings', () => {
           done();
         })
   });
-  it('should return an object with a data and 200 status when when deleting a booking with valid creadentials', (done) => {
+  it('should return an object with a data and message property with a 200 status when the booking is deleted successfully', (done) => {
       chai
         .request(app)
         .delete(`/api/v1/bookings/${1}`)
         .set('Content-type', 'application/json')
-        .set('Content-type', 'application/x-www-form-urlencoded')
         .set('Authorization', `Bearer ${authToken}`)
         .send()
         .end((err, res) => {
@@ -238,8 +237,60 @@ describe('Bookings', () => {
           expect(res).to.have.status(200)
           expect(res.body).to.be.an('object')
           expect(res.body).to.have.property('data')
-          expect(res.body.data.message).to.equal('Booking deleted successfully')
+          expect(res.body.data).to.have.property('message')
+          expect(res.body.status).to.equal('success')
           done();
         })
   });
+  it('should return an object with a data and 401 status when the user trying to view bookings is noft authenticated', (done) => {
+      chai
+        .request(app)
+        .get(`/api/v1/bookings`)
+        .set('Content-type', 'application/json')
+        .send()
+        .end((err, res) => {
+          if (err) done(err);
+          expect(res).to.have.status(401)
+          expect(res.body).to.be.an('object')
+          expect(res.body).to.have.property('error')
+          expect(res.body.status).to.equal('error')
+          done();
+        })
+  });
+  it('should return an object with a data and 200 status when the user trying to view bookings is authenticated', (done) => {
+      chai
+        .request(app)
+        .get(`/api/v1/bookings`)
+        .set('Content-type', 'application/json')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send()
+        .end((err, res) => {
+          if (err) done(err);
+          expect(res).to.have.status(200)
+          expect(res.body).to.be.an('object')
+          expect(res.body).to.have.property('data')
+          expect(res.body.data).to.be.an('array')
+          expect(res.body.status).to.equal('success')
+          done();
+        })
+  });
+  it('should return an object with a data with only user bookings and 200 status when the user trying to view bookings is not an admin', (done) => {
+      chai
+        .request(app)
+        .get(`/api/v1/bookings`)
+        .set('Content-type', 'application/json')
+        .set('Authorization', `Bearer ${userToken}`)
+        .send()
+        .end((err, res) => {
+          if (err) done(err);
+          expect(res).to.have.status(200)
+          expect(res.body).to.be.an('object')
+          expect(res.body).to.have.property('data')
+          expect(res.body.data).to.be.an('array')
+          expect(res.body.status).to.equal('success')
+          done();
+        })
+  });
+
+
 })


### PR DESCRIPTION
implement viewing bookings for both users and admins
[finishes #167417712]

#### What does this PR do?
implement view bookings
#### Description of Task to be completed?
Hence is the implementation to view bookings for both users and admins 
#### How should this be manually tested?
To test this feature [here](https://way-farer-app-rest.herokuapp.com/api/v1/bookings).
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/167417712